### PR TITLE
Removed default --min-self-delegation flag

### DIFF
--- a/cmd/cudos-noded/cmd/root.go
+++ b/cmd/cudos-noded/cmd/root.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -37,12 +36,9 @@ import (
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/cosmos/cosmos-sdk/x/crisis"
 	genutilcli "github.com/cosmos/cosmos-sdk/x/genutil/client/cli"
-	stakingFlags "github.com/cosmos/cosmos-sdk/x/staking/client/cli"
 )
 
 var ChainID string
-
-var minSelfDelegationValueLowerBoundString string = "2000000000000000000000000"
 
 // NewRootCmd creates a new root command for simd. It is called once in the
 // main function.
@@ -66,44 +62,15 @@ func NewRootCmd() (*cobra.Command, params.EncodingConfig) {
 				return err
 			}
 
-			flagMinSelfDelegation := cmd.Flags().Lookup(stakingFlags.FlagMinSelfDelegation)
-			if flagMinSelfDelegation != nil {
-				minSelfDelegationValueString, err := cmd.Flags().GetString(stakingFlags.FlagMinSelfDelegation)
-				if err != nil {
-					return fmt.Errorf("flag %s is not a valid number", stakingFlags.FlagMinSelfDelegation)
-				}
-				minSelfDelegationValueBigInt, ok := sdk.NewIntFromString(minSelfDelegationValueString)
-				if !ok {
-					return fmt.Errorf("flag %s is not a valid number", stakingFlags.FlagMinSelfDelegation)
-				}
-				minSelfDelegationValueLowerBoundBigInt, _ := sdk.NewIntFromString(minSelfDelegationValueLowerBoundString)
-				if minSelfDelegationValueBigInt.LT(minSelfDelegationValueLowerBoundBigInt) {
-					return fmt.Errorf("flag %s must be >= 2 000 000 000 000 000 000 000 000", stakingFlags.FlagMinSelfDelegation)
-				}
-			}
-
 			return server.InterceptConfigsPreRunHandler(cmd, "", nil)
 		},
 	}
 
 	initRootCmd(rootCmd, encodingConfig)
 	overwriteFlagDefaults(rootCmd, map[string]string{
-		flags.FlagChainID:                  ChainID,
-		flags.FlagKeyringBackend:           "os",
-		stakingFlags.FlagMinSelfDelegation: minSelfDelegationValueLowerBoundString,
+		flags.FlagChainID:        ChainID,
+		flags.FlagKeyringBackend: "os",
 	})
-
-	// flag := rootCmd.Flags().Lookup("long")
-	// fmt.Println(flag)
-
-	// rootCmd.PersistentPreRunE()
-
-	// value, err := rootCmd.Flags().GetString(flags.FlagKeyringBackend)
-	// if err != nil {
-	// 	panic(err)
-	// } else {
-	// 	fmt.Printf("Debug %s\n", value)
-	// }
 
 	return rootCmd, encodingConfig
 }

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,14 @@ module github.com/CudoVentures/cudos-node
 go 1.15
 
 // replace github.com/althea-net/cosmos-gravity-bridge/module => ../CudosGravityBridge/module
+
 replace github.com/althea-net/cosmos-gravity-bridge/module => github.com/CudoVentures/cosmos-gravity-bridge/module v0.0.0-20220317074327-99aa0dce200c
 
 replace github.com/CosmWasm/wasmd => github.com/provenance-io/wasmd v0.17.1-0.20210812214331-ce3a93a9268d
 
-replace github.com/cosmos/cosmos-sdk => github.com/CudoVentures/cosmos-sdk v0.0.0-20220315151738-5b62b1f9414b
+replace github.com/cosmos/cosmos-sdk => github.com/CudoVentures/cosmos-sdk v0.0.0-20220322143015-0a40a92cb9bf
+
+// replace github.com/cosmos/cosmos-sdk => ../cosmos-sdk
 
 // replace globally the grpc version (https://docs.cosmos.network/v0.44/basics/app-anatomy.html#dependencies-and-makefile)
 replace google.golang.org/grpc => google.golang.org/grpc v1.33.2

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/CosmWasm/wasmvm v0.16.0 h1:87jyCTcCpuSx7a8s5ed9N/E/XV13XZflxa0/OplwSm
 github.com/CosmWasm/wasmvm v0.16.0/go.mod h1:Id107qllDJyJjVQQsKMOy2YYF98sqPJ2t+jX1QES40A=
 github.com/CudoVentures/cosmos-gravity-bridge/module v0.0.0-20220317074327-99aa0dce200c h1:9LCPMqHIXRWAUmsI0/s2l+7Gbe4KasCaEx7WQ+Lec1A=
 github.com/CudoVentures/cosmos-gravity-bridge/module v0.0.0-20220317074327-99aa0dce200c/go.mod h1:H8UZtKLMu0jmkRbIGsECxomAflwjPfm/kPSzrbqHC+A=
-github.com/CudoVentures/cosmos-sdk v0.0.0-20220315151738-5b62b1f9414b h1:bq51aUveZOQnU4+pwdS9B9ld6/bdi/lTa40e/mUcCeo=
-github.com/CudoVentures/cosmos-sdk v0.0.0-20220315151738-5b62b1f9414b/go.mod h1:maUA6m2TBxOJZkbwl0eRtEBgTX37kcaiOWU5t1HEGaY=
+github.com/CudoVentures/cosmos-sdk v0.0.0-20220322143015-0a40a92cb9bf h1:aayn4BscnHAHO70b0Kb09UEZj3XprRGGeI1FyPo5+FE=
+github.com/CudoVentures/cosmos-sdk v0.0.0-20220322143015-0a40a92cb9bf/go.mod h1:maUA6m2TBxOJZkbwl0eRtEBgTX37kcaiOWU5t1HEGaY=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=


### PR DESCRIPTION
The problem here was that the --min-self-delegation was set as default to all CLI commands. From there the edit-validator command was trying to set new value for min self delegation, which per cosmos-sdk can't be the less than or equal to the previous.

I've removed the flag and set the cosmos-sdk commit to the one where we have the min-self-delegation done in msg.ValdiateBasic, which is a better solution.