### PR TITLE
Fixing CLANG Build error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ BUILD_FLAGS := -ldflags '$(ldflags)'
 
 all: install
 
-install: export CGO_LDFLAGS="-Wl,-rpath,$$ORIGIN/../"
+install: export CGO_LDFLAGS=-Wl,-rpath,$$ORIGIN/../
 install: go.sum
 		@echo "--> Installing cudos-noded"
 		@go install -mod=readonly $(BUILD_FLAGS) -tags "ledger" ./cmd/cudos-noded
 
 
-build: export CGO_LDFLAGS="-Wl,-rpath,$$ORIGIN/../"
+build: export CGO_LDFLAGS=-Wl,-rpath,$$ORIGIN/../
 build: go.sum
 		@echo "--> Building cudos-noded"
 		@go build -mod=readonly $(BUILD_FLAGS) -o $(BUILDDIR)/ -tags "ledger" ./cmd/cudos-noded


### PR DESCRIPTION
Make install OR Make build with the old Make file version was giving me the following error in the console:

clang: error: no such file or directory: "-Wl,-rpath,$ORIGIN/../"

after some tries with changes here and there, it seems to be working after removing the quotes, thus proposing this update to the make file.