### PR TITLE
Add wasmd to the IBC router

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -180,6 +180,7 @@ func New(
 	// Create static IBC router, add transfer route, then set and seal it
 	ibcRouter := porttypes.NewRouter()
 	ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferModule)
+	ibcRouter.AddRoute(wasm.ModuleName, wasm.NewIBCHandler(app.wasmKeeper, app.IBCKeeper.ChannelKeeper))
 	app.IBCKeeper.SetRouter(ibcRouter)
 
 	app.mm = module.NewManager(


### PR DESCRIPTION
Without this, it is impossible to connect an IBC channel to a contract.

This is copied from the app.go of the upstream CosmWasm/wasmd repo.