### PR TITLE
marketplace: Fix NFT transfer incomplete store update

### DIFF
--- a/x/marketplace/keeper/keeper.go
+++ b/x/marketplace/keeper/keeper.go
@@ -173,7 +173,7 @@ func (k Keeper) BuyNFT(ctx sdk.Context, nftID uint64, buyer sdk.AccAddress) (typ
 		return types.Nft{}, err
 	}
 
-	k.nftKeeper.TransferNftInternal(ctx, nft.DenomId, nft.TokenId, sdk.AccAddress(nft.Owner), buyer, baseNft)
+	k.nftKeeper.TransferNftInternal(ctx, nft.DenomId, nft.TokenId, baseNft.GetOwner(), buyer, baseNft)
 
 	return nft, nil
 }


### PR DESCRIPTION
`nft.Owner` is _already_ the Bech32-encoded address of the owner of the marketplace listing, and `BuyNFT` causes it to be encoded a second time by passing it to `sdk.AccAddress(nft.Owner)`.

The correct approach to converting `nft.Owner` to an `AccAddress` is to use `sdk.AccAddressFromBech32`.

However, an _additional_ problem is that `nft.Owner` is the owner of the marketplace listing, but for the NFT module keeper we need the owner of the NFT itself. The correct owner for passing to `TransferNftInternal` is obtained via `baseNft.GetOwner()`.

Because these faults in combination lead to the wrong address being sent to `TransferNftInternal` in the NFT module, the previous ownership is not correctly cleared from the store, and `cudos-noded query nft owner` returns incorrect information.