### PR TITLE
Don't panic on jailing

### DIFF
--- a/app/app_keepers.go
+++ b/app/app_keepers.go
@@ -87,11 +87,11 @@ func (app *App) AddKeepers(skipUpgradeHeights map[int64]bool, homePath string, a
 		app.appCodec, app.keys[banktypes.StoreKey], app.AccountKeeper, app.GetSubspace(banktypes.ModuleName), app.BlockedAddrs(),
 	)
 	stakingKeeper := stakingkeeper.NewKeeper(
-		app.appCodec, app.keys[stakingtypes.StoreKey], app.AccountKeeper, bankKeeper, app.GetSubspace(stakingtypes.ModuleName),
+		app.appCodec, app.keys[stakingtypes.StoreKey], app.AccountKeeper, &bankKeeper, app.GetSubspace(stakingtypes.ModuleName),
 	)
 
 	app.DistrKeeper = distrkeeper.NewKeeper(
-		app.appCodec, app.keys[distrtypes.StoreKey], app.GetSubspace(distrtypes.ModuleName), app.AccountKeeper, bankKeeper,
+		app.appCodec, app.keys[distrtypes.StoreKey], app.GetSubspace(distrtypes.ModuleName), app.AccountKeeper, &bankKeeper,
 		&stakingKeeper, authtypes.FeeCollectorName, app.ModuleAccountAddrs(),
 	)
 


### PR DESCRIPTION
The staking keeper receives a copy of the bank keeper, before it has been configured to burn tokens correctly.

This causes a panic if it ever tries to burn tokens - e.g. if it is jailing a validator.

This patch passes the bank keeper to the staking keeper by reference instead.

For the sake of completeness, it also passes it by reference to the distribution keeper, although that isn't related to the panic.